### PR TITLE
Forcing the index.js file to 'use strict'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const gulpUtil = require('gulp-util');
 const InlineEnviromentVariablesPlugin = require('inline-environment-variables-webpack-plugin');
 


### PR DESCRIPTION
The following issue outlines why this particular project may not work in environments where strict checking is enabled in ES6: #2 

Resolution for the problem is provided in the following PR.